### PR TITLE
修复log4j远程代码执行漏洞

### DIFF
--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8.1</version>
+            <version>2.12.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.8.1</version>
+            <version>2.12.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
更新log4j版本以修复CVE-2021-44832导致的RCE漏洞